### PR TITLE
fixed for version 1.8.0

### DIFF
--- a/ArenaExpansion.csproj
+++ b/ArenaExpansion.csproj
@@ -30,13 +30,30 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\..\..\Program Files %28x86%29\Steam\steamapps\common\Mount &amp; Blade II Bannerlord\Modules\mewhi-ArenaExpansion\bin\Win64_Shipping_Client\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.0.0.8, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\bin\Win64_Shipping_Client\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.2.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Lib.Harmony.2.2.2\lib\net472\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="SandBox">
-      <HintPath>..\..\..\SandBox\bin\Win64_Shipping_Client\SandBox.dll</HintPath>
+      <HintPath>..\..\..\Program Files (x86)\Steam\steamapps\common\Mount &amp; Blade II Bannerlord\Modules\SandBox\bin\Win64_Shipping_Client\SandBox.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -49,40 +66,43 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="TaleWorlds.CampaignSystem">
-      <HintPath>..\..\..\..\bin\Win64_Shipping_Client\TaleWorlds.CampaignSystem.dll</HintPath>
+      <HintPath>..\..\..\Program Files (x86)\Steam\steamapps\common\Mount &amp; Blade II Bannerlord\bin\Win64_Shipping_Client\TaleWorlds.CampaignSystem.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="TaleWorlds.Core">
-      <HintPath>..\..\..\..\bin\Win64_Shipping_Client\TaleWorlds.Core.dll</HintPath>
+      <HintPath>..\..\..\Program Files (x86)\Steam\steamapps\common\Mount &amp; Blade II Bannerlord\bin\Win64_Shipping_Client\TaleWorlds.Core.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="TaleWorlds.DotNet">
-      <HintPath>..\..\..\..\bin\Win64_Shipping_Client\TaleWorlds.DotNet.dll</HintPath>
+      <HintPath>..\..\..\Program Files (x86)\Steam\steamapps\common\Mount &amp; Blade II Bannerlord\bin\Win64_Shipping_Client\TaleWorlds.DotNet.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="TaleWorlds.Engine">
-      <HintPath>..\..\..\..\bin\Win64_Shipping_Client\TaleWorlds.Engine.dll</HintPath>
+      <HintPath>..\..\..\Program Files (x86)\Steam\steamapps\common\Mount &amp; Blade II Bannerlord\bin\Win64_Shipping_Client\TaleWorlds.Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="TaleWorlds.Engine.GauntletUI">
-      <HintPath>..\..\..\..\bin\Win64_Shipping_Client\TaleWorlds.Engine.GauntletUI.dll</HintPath>
+      <HintPath>..\..\..\Program Files (x86)\Steam\steamapps\common\Mount &amp; Blade II Bannerlord\bin\Win64_Shipping_Client\TaleWorlds.Engine.GauntletUI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="TaleWorlds.GauntletUI">
-      <HintPath>..\..\..\..\bin\Win64_Shipping_Client\TaleWorlds.GauntletUI.dll</HintPath>
+      <HintPath>..\..\..\Program Files (x86)\Steam\steamapps\common\Mount &amp; Blade II Bannerlord\bin\Win64_Shipping_Client\TaleWorlds.GauntletUI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="TaleWorlds.Library">
-      <HintPath>..\..\..\..\bin\Win64_Shipping_Client\TaleWorlds.Library.dll</HintPath>
+      <HintPath>..\..\..\Program Files (x86)\Steam\steamapps\common\Mount &amp; Blade II Bannerlord\bin\Win64_Shipping_Client\TaleWorlds.Library.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="TaleWorlds.Localization">
-      <HintPath>..\..\..\..\bin\Win64_Shipping_Client\TaleWorlds.Localization.dll</HintPath>
+      <HintPath>..\..\..\Program Files (x86)\Steam\steamapps\common\Mount &amp; Blade II Bannerlord\bin\Win64_Shipping_Client\TaleWorlds.Localization.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="TaleWorlds.MountAndBlade">
-      <HintPath>..\..\..\..\bin\Win64_Shipping_Client\TaleWorlds.MountAndBlade.dll</HintPath>
+      <HintPath>..\..\..\Program Files (x86)\Steam\steamapps\common\Mount &amp; Blade II Bannerlord\bin\Win64_Shipping_Client\TaleWorlds.MountAndBlade.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="TaleWorlds.ObjectSystem">
+      <HintPath>..\..\..\Program Files (x86)\Steam\steamapps\common\Mount &amp; Blade II Bannerlord\bin\Win64_Shipping_Client\TaleWorlds.ObjectSystem.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -92,6 +112,9 @@
     <Compile Include="MWAXConfig.cs" />
     <Compile Include="MWAXCore.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/ArenaExpansion.sln
+++ b/ArenaExpansion.sln
@@ -1,20 +1,26 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29926.136
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32922.545
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArenaExpansion", "ArenaExpansion.csproj", "{22745A74-6AD7-41B8-BAAE-305D8F6D5C11}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{22745A74-6AD7-41B8-BAAE-305D8F6D5C11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{22745A74-6AD7-41B8-BAAE-305D8F6D5C11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22745A74-6AD7-41B8-BAAE-305D8F6D5C11}.Debug|x64.ActiveCfg = Debug|x64
+		{22745A74-6AD7-41B8-BAAE-305D8F6D5C11}.Debug|x64.Build.0 = Debug|x64
 		{22745A74-6AD7-41B8-BAAE-305D8F6D5C11}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{22745A74-6AD7-41B8-BAAE-305D8F6D5C11}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22745A74-6AD7-41B8-BAAE-305D8F6D5C11}.Release|x64.ActiveCfg = Release|x64
+		{22745A74-6AD7-41B8-BAAE-305D8F6D5C11}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MWAXArenaMasterDialoguePatch.cs
+++ b/MWAXArenaMasterDialoguePatch.cs
@@ -1,21 +1,22 @@
 ﻿using HarmonyLib;
+using SandBox.CampaignBehaviors;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Conversation;
 using TaleWorlds.MountAndBlade;
-using SandBox.Source.Towns;
 
 namespace ArenaExpansion {
-    [HarmonyPatch(typeof(ArenaMaster), "AddDialogs")]
+    [HarmonyPatch(typeof(ArenaMasterCampaignBehavior), "AddDialogs")]
     class MWAXArenaMasterDialoguePatch {
-        private static bool Prefix(ArenaMaster __instance, CampaignGameStarter campaignGameStarter) {
+        private static bool Prefix(CampaignGameStarter campaignGameStarter) {
             campaignGameStarter.AddDialogLine("mwax_arena_entered_from_menu", "start", "mwax_arena_weapons_list", "{=mwax_arena_2}Alright, which weapon are you taking?", new ConversationSentence.OnConditionDelegate(MWAXArenaMasterDialoguePatch.MWAX_conversation_choose_weapon_condition), (ConversationSentence.OnConsequenceDelegate)null, 100, (ConversationSentence.OnClickableConditionDelegate)null);
             return true;
         }
 
         private static bool MWAX_conversation_choose_weapon_condition() {
-            if (Mission.Current.GetMissionBehaviour<MWAXArenaWeaponSwapLogic>() == null)
+            if (Mission.Current.GetMissionBehavior<MWAXArenaWeaponSwapLogic>() == null)
                 return false;
 
-            return Mission.Current.GetMissionBehaviour<MWAXArenaWeaponSwapLogic>().MWAXEnteredFromMenu;
+            return Mission.Current.GetMissionBehavior<MWAXArenaWeaponSwapLogic>().MWAXEnteredFromMenu;
         }
     }
 }

--- a/MWAXArenaWeaponSwapLogic.cs
+++ b/MWAXArenaWeaponSwapLogic.cs
@@ -4,6 +4,11 @@ using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
 using SandBox;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.CampaignSystem.Encounters;
+using SandBox.Missions.MissionLogics.Arena;
+using TaleWorlds.CampaignSystem.Conversation;
+using SandBox.Conversation;
 
 namespace ArenaExpansion {
     public class MWAXArenaWeaponSwapLogic : MissionLogic {
@@ -24,9 +29,9 @@ namespace ArenaExpansion {
 
         public override void OnMissionTick(float dt) {
             base.OnMissionTick(dt);
-
+            
             if (this.MWAXEnteredFromMenu) {
-                MissionConversationHandler.Current.StartConversation(this.Mission.Agents.FirstOrDefault<Agent>((Func<Agent, bool>)(x => x.Character != null && ((CharacterObject)x.Character).Occupation == Occupation.ArenaMaster)), true, false);
+                ConversationMission.StartConversationWithAgent(this.Mission.Agents.FirstOrDefault<Agent>((Func<Agent, bool>)(x => x.Character != null && ((CharacterObject)x.Character).Occupation == Occupation.ArenaMaster)));
                 this.MWAXEnteredFromMenu = false;
             }
 
@@ -38,7 +43,7 @@ namespace ArenaExpansion {
 
             this.player = Agent.Main;
 
-            ArenaPracticeFightMissionController missionBehaviour = Mission.Current.GetMissionBehaviour<ArenaPracticeFightMissionController>();
+            ArenaPracticeFightMissionController missionBehaviour = Mission.Current.GetMissionBehavior<ArenaPracticeFightMissionController>();
 
             if (this.player != null && missionBehaviour.IsPlayerPracticing) {
                 this.SwapEquipment(this.player, this.MWAXLoadout);
@@ -54,7 +59,7 @@ namespace ArenaExpansion {
                 EquipmentElement equipmentFromSlot = characterObject.BattleEquipments.ToList<Equipment>()[loadout].GetEquipmentFromSlot((EquipmentIndex)i);
                 agent.RemoveEquippedWeapon((EquipmentIndex)i);
                 if (equipmentFromSlot.Item != null) {
-                    MissionWeapon missionWeapon = new MissionWeapon(equipmentFromSlot.Item, agent.Origin?.Banner);
+                    MissionWeapon missionWeapon = new MissionWeapon(equipmentFromSlot.Item, equipmentFromSlot.ItemModifier, agent.Origin?.Banner);
                     agent.EquipWeaponWithNewEntity((EquipmentIndex)i, ref missionWeapon);
                 }
             }

--- a/MWAXCore.cs
+++ b/MWAXCore.cs
@@ -3,6 +3,7 @@ using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.Library;
 using SandBox;
+using SandBox.Missions.MissionLogics.Arena;
 
 namespace ArenaExpansion {
     public class MWAXCore : MBSubModuleBase {
@@ -35,8 +36,8 @@ namespace ArenaExpansion {
             base.OnGameLoaded(game, initializerObject);
         }
 
-        public override void OnMissionBehaviourInitialize(Mission mission) {
-            base.OnMissionBehaviourInitialize(mission);
+        public override void OnMissionBehaviorInitialize(Mission mission) {
+            base.OnMissionBehaviorInitialize(mission);
 
             this.AddMissionBehaviours(mission);
         }
@@ -46,10 +47,10 @@ namespace ArenaExpansion {
         }
 
         private void AddMissionBehaviours(Mission mission) {
-            if (mission.HasMissionBehaviour<MWAXArenaWeaponSwapLogic>() || !mission.HasMissionBehaviour<ArenaPracticeFightMissionController>())
+            if (mission.HasMissionBehavior<MWAXArenaWeaponSwapLogic>() || !mission.HasMissionBehavior<ArenaPracticeFightMissionController>())
                 return;
 
-            mission.AddMissionBehaviour((MissionBehaviour)new MWAXArenaWeaponSwapLogic());
+            mission.AddMissionBehavior((MissionBehavior)new MWAXArenaWeaponSwapLogic());
         }
     }
 }

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Lib.Harmony" version="2.2.2" targetFramework="net472" />
+</packages>


### PR DESCRIPTION
Tested on vanilla 1.8.0.

One thing to note is that in MWAXArenaMaster.cs in lines 87 and 93 theres the ConsequenceDelegate that triggers MWAX_game_menu_choose_weapon() as if the dialog was started from the GameMenu. I had to do that as I couldn't get the dialog to work properly. (likely 'cause I don't understand the conversation system) This isn't game breaking tho.